### PR TITLE
fix: play alien intro video (same-origin /videos/, correct Content-Type)

### DIFF
--- a/index.html
+++ b/index.html
@@ -352,7 +352,7 @@
     <div class="video-intro" id="videoIntro"
         style="display: none; position: fixed; inset: 0; background: #000; z-index: 999; opacity: 0; pointer-events: none; transition: opacity 0.5s;">
         <video id="introVideo" style="width: 100%; height: 100%; object-fit: cover;" preload="auto" playsinline>
-            <source src="https://raw.githubusercontent.com/jackspace/djjackspace/main/videos/alien-intro.mp4"
+            <source src="/videos/alien-intro.mp4"
                 type="video/mp4">
             Your browser does not support video playback.
         </video>
@@ -547,7 +547,7 @@
             <div class="video-intro" id="videoIntro"
                 style="display: none; position: fixed; inset: 0; background: #000; z-index: 999; opacity: 0; pointer-events: none; transition: opacity 0.5s;">
                 <video id="introVideo" style="width: 100%; height: 100%; object-fit: cover;" preload="auto" playsinline>
-                    <source src="https://raw.githubusercontent.com/jackspace/djjackspace/main/videos/alien-intro.mp4"
+                    <source src="/videos/alien-intro.mp4"
                         type="video/mp4">
                     Your browser does not support video playback.
                 </video>


### PR DESCRIPTION
The intro video pointed at `raw.githubusercontent.com`, which serves the `.mp4` as `application/octet-stream` — browsers refuse to play that in a `<video>` element. The same file is already served by Cloudflare Pages at `/videos/alien-intro.mp4` as `video/mp4` with byte-range support, so both `<source>` tags now use the same-origin path. Two-line change, nothing else touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
